### PR TITLE
Support `1. e4 1... e5` format. Closes issue #14

### DIFF
--- a/pgn_test.go
+++ b/pgn_test.go
@@ -203,3 +203,16 @@ func (s *PGNSuite) TestIssue9(c *C) {
 		c.Fatal(err)
 	}
 }
+
+var issue14 = `
+1. e4 {[%clk 0:15:09.9]} 1... Nc6 {[%clk 0:15:06.6]} 2. Nf3 {[%clk 0:15:15.1]} 2... e5 {[%clk 0:15:02.9]} 3. Bc4 {[%clk 0:15:16.9]} 3... h6 {[%clk 0:14:39.1]} 4. d4 {[%clk 0:15:23.1]} 4... exd4 {[%clk 0:14:30.7]} 5. Nxd4 {[%clk 0:15:29.1]} 5... Bc5 {[%clk 0:14:19]} 6. c3 {[%clk 0:15:06.4]} 6... Qe7 {[%clk 0:14:17.3]} 7. Qf3 {[%clk 0:14:48]} 7... Nf6 {[%clk 0:14:22.9]} 8. O-O {[%clk 0:14:49.9]} 8... Qxe4 {[%clk 0:14:00.9]} 9. Qxe4+ {[%clk 0:14:51]} 9... Nxe4 {[%clk 0:14:07.7]} 10. Re1 {[%clk 0:15:00.2]} 10... f5 {[%clk 0:13:48.3]} 11. f3 {[%clk 0:14:47.9]} 11... Bxd4+ {[%clk 0:12:38.1]} 12. cxd4 {[%clk 0:14:57.8]} 12... Nxd4 {[%clk 0:12:47]} 1-0`
+
+func (s *PGNSuite) TestIssue14(c *C) {
+	r := strings.NewReader(issue14)
+	sc := scanner.Scanner{}
+	sc.Init(r)
+	_, err := ParseGame(&sc)
+	if err != nil {
+		c.Fatal(err)
+	}
+}


### PR DESCRIPTION
Includes a testcase . Had to refactor the parser a tiny bit, because it was hard to fit in otherwise.